### PR TITLE
Update 2023-09-04-deserialization-untrusted-data-CWE-502-part2.md

### DIFF
--- a/_posts/2023-09-04-deserialization-untrusted-data-CWE-502-part2.md
+++ b/_posts/2023-09-04-deserialization-untrusted-data-CWE-502-part2.md
@@ -110,7 +110,7 @@ Phar wrapper cannot be disabled via a php.ini settings.
 
 As a developer:
 * A strict validation of input data is absolutely essential!
-* Use `basename()` PHP method to prevent path traversal `getimagesize(_PS_IMG_DIR_ . basename($_GET['param']))` and unwanted use of wrapper such as `phar://`
+* Use `basename()` PHP method to prevent path traversal and unwanted use of wrapper such as `phar://` : `getimagesize(basename($_GET['param']))`
 * Use the GD library to remove dummy serialized data from an image.
 
 As an admin sys:


### PR DESCRIPTION
Pour éviter de trop perdre les gens vu que `getimagesize(_PS_IMG_DIR_ . basename($_GET['param']))` est sans risque contre une CWE 502, c'est uniquement pour traiter une CWE 22.