### PR TITLE
add docker compose

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"
 gem "jekyll-paginate"
+gem "webrick"

--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ If the CVE is published by Friends of Presta.
 
 4. Publish a Pull Request.
 5. Wait for the validation of our team.
+
+## How to work locally with  jekyll
+
+Use the provided docker-compose with: `docker-compose up`.
+
+The website will be available from [http://127.0.0.1:4000](http://127.0.0.1:4000).

--- a/_config.yml
+++ b/_config.yml
@@ -29,3 +29,6 @@ plugins:
  - jekyll-feed
  - jekyll-seo-tag
  - jekyll-paginate
+
+exclude:
+  - docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  jekyll:
+    image: bretfisher/jekyll-serve
+    volumes:
+      - .:/site
+    ports:
+      - '4000:4000'


### PR DESCRIPTION
- DOcker compose to work with jekyll without installing gem and ruby locally
- Add instruction in the readme
