### PR TITLE
Fix patch (Detected pattern in reportsstatistics.php)

### DIFF
--- a/_posts/2024-03-14-reportsstatistics.md
+++ b/_posts/2024-03-14-reportsstatistics.md
@@ -69,12 +69,14 @@ if(file_exists(dirname(__FILE__).'/'.$file))
 
 
 ```diff
---- 1.3.12/module/reportsstatistics/ajax_public.php
-+++ XXXXXX/module/reportsstatistics/ajax_public.php
-...
--			$current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields), true);
-+			$current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields, ['allowed_classes' => false]), true); // Harmless until proven otherwise just for the principle.
-...
+--- 1.3.12/module/reportsstatistics/reportsstatistics.php
++++ XXXXXX/module/reportsstatistics/reportsstatistics.php
+@@ -643 +643 @@ class reportsstatistics extends Module
+-            $current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields), true);
++            $current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields, ['allowed_classes' => false]), true); // Harmless until proven otherwise just for the principle.
+@@ -670 +670 @@ class reportsstatistics extends Module
+-            $current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields), true);
++            $current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields, ['allowed_classes' => false]), true); // Harmless until proven otherwise just for the principle.
 ```
 
 ## Other recommendations

--- a/_posts/2024-03-14-reportsstatistics.md
+++ b/_posts/2024-03-14-reportsstatistics.md
@@ -69,7 +69,18 @@ if(file_exists(dirname(__FILE__).'/'.$file))
 
 
 ```diff
---- 1.3.12/module/reportsstatistics/reportsstatistics.php
+--- 1.3.12/module/reportsstatistics/ajax_public.php
++++ XXXXXX/module/reportsstatistics/ajax_public.php
+...
+-			$current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields), true);
++			$current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields, ['allowed_classes' => false]), true); // Harmless until proven otherwise just for the principle.
+...
+```
+
+Seen by a contributor in 1.3.20 :
+
+```diff
+--- 1.3.20/module/reportsstatistics/reportsstatistics.php
 +++ XXXXXX/module/reportsstatistics/reportsstatistics.php
 @@ -643 +643 @@ class reportsstatistics extends Module
 -            $current_value = Tools::jsonDecode(unserialize($context->cookie->apc_fields), true);


### PR DESCRIPTION
The pattern was detected in `module/reportsstatistics/reportsstatistics.php` instead of `module/reportsstatistics/ajax_public.php`.

I don't know if it's an error, or if the version that I have (1.3.20) simply does not have an `ajax_public.php` anymore.